### PR TITLE
Fixed Url Parameter for Checkout

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -127,7 +127,7 @@ class Checkout implements Responsable
         }
 
         if ($this->custom) {
-            $checkout = array_merge($checkout, ['custom' => array_filter($this->custom)]);
+            $checkout = array_merge($checkout, ['custom' => $this->custom]);
         }
 
         if (count($checkout) > 0) {

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -121,12 +121,17 @@ class Checkout implements Responsable
             ->filter(fn ($toggle) => ! $this->{$toggle})
             ->mapWithKeys(fn ($toggle) => [$toggle => 0]);
 
+        $checkout = [];
         if ($this->fields) {
-            $params = $params->merge(array_filter($this->fields));
+            $checkout = array_merge($checkout, $this->fields);
         }
 
         if ($this->custom) {
-            $params['checkout'] = ['custom' => $this->custom];
+            $checkout = array_merge($checkout, ['custom' => $this->custom]);
+        }
+
+        if (count($checkout) > 0) {
+            $params['checkout'] = array_filter($checkout);
         }
 
         $params = $params->isNotEmpty() ? '?'.http_build_query($params->all()) : '';

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -123,15 +123,15 @@ class Checkout implements Responsable
 
         $checkout = [];
         if ($this->fields) {
-            $checkout = array_merge($checkout, $this->fields);
+            $checkout = array_merge($checkout, array_filter($this->fields));
         }
 
         if ($this->custom) {
-            $checkout = array_merge($checkout, ['custom' => $this->custom]);
+            $checkout = array_merge($checkout, ['custom' => array_filter($this->custom)]);
         }
 
         if (count($checkout) > 0) {
-            $params['checkout'] = array_filter($checkout);
+            $params['checkout'] = $checkout;
         }
 
         $params = $params->isNotEmpty() ? '?'.http_build_query($params->all()) : '';

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -39,7 +39,7 @@ it('can set prefilled fields with dedicated methods', function () {
         ->withDiscountCode('10PERCENTOFF');
 
     expect($checkout->url())
-        ->toBe('https://lemon.lemonsqueezy.com/checkout/buy/variant_123?name=John+Doe&email=john%40example.com&billing_address%5Bcountry%5D=US&billing_address%5Bstate%5D=NY&billing_address%5Bzip%5D=10038&tax_number=GB123456789&discount_code=10PERCENTOFF');
+        ->toBe('https://lemon.lemonsqueezy.com/checkout/buy/variant_123?checkout%5Bname%5D=John+Doe&checkout%5Bemail%5D=john%40example.com&checkout%5Bbilling_address%5D%5Bcountry%5D=US&checkout%5Bbilling_address%5D%5Bstate%5D=NY&checkout%5Bbilling_address%5D%5Bzip%5D=10038&checkout%5Btax_number%5D=GB123456789&checkout%5Bdiscount_code%5D=10PERCENTOFF');
 });
 
 it('can include custom data', function () {
@@ -50,4 +50,15 @@ it('can include custom data', function () {
 
     expect($checkout->url())
         ->toBe('https://lemon.lemonsqueezy.com/checkout/buy/variant_123?checkout%5Bcustom%5D%5Border_id%5D=789');
+});
+
+it('can include prefilled fields and custom data', function () {
+    $checkout = Checkout::make('lemon', 'variant_123')
+        ->withName('John Doe')
+        ->withCustomData([
+            'order_id' => '789',
+        ]);
+
+    expect($checkout->url())
+        ->toBe('https://lemon.lemonsqueezy.com/checkout/buy/variant_123?checkout%5Bname%5D=John+Doe&checkout%5Bcustom%5D%5Border_id%5D=789');
 });


### PR DESCRIPTION
Fixed the parameters for checkout based on the documentation: 
- https://docs.lemonsqueezy.com/help/checkout/prefilling-checkout-fields

Before fix:
- ?email=hello@example.com

After fix:
- ?checkout[email]=hello@example.com

Tests are updated accordingly.