### PR TITLE
Added events and controller for payment-related webhooks

### DIFF
--- a/src/Events/SubscriptionPaymentFailed.php
+++ b/src/Events/SubscriptionPaymentFailed.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use LemonSqueezy\Laravel\Subscription;
 
-class SubscriptionPaused
+class SubscriptionPaymentFailed
 {
     use Dispatchable, SerializesModels;
 

--- a/src/Events/SubscriptionPaymentRecovered.php
+++ b/src/Events/SubscriptionPaymentRecovered.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use LemonSqueezy\Laravel\Subscription;
 
-class SubscriptionPaused
+class SubscriptionPaymentRecovered
 {
     use Dispatchable, SerializesModels;
 

--- a/src/Events/SubscriptionPaymentSuccess.php
+++ b/src/Events/SubscriptionPaymentSuccess.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use LemonSqueezy\Laravel\Subscription;
 
-class SubscriptionPaused
+class SubscriptionPaymentSuccess
 {
     use Dispatchable, SerializesModels;
 


### PR DESCRIPTION
Hi Dries,

I tried to add events for the payment success/failure/recovered events, but I hit a problem with my local set up (I'm on windows, using sail, under WSL, synching from files within the normal windows drive). And I hit provided unknown errors because of this, but I'm pretty sure they're because of my set up, not the code I've changed.

So I'm submitting this, but it's 100% untested. Hopefully, it'll save you a bit of work, however.

Andy