### PR TITLE
Add "down" method for migrations

### DIFF
--- a/database/migrations/2023_01_16_000001_create_customers_table.php
+++ b/database/migrations/2023_01_16_000001_create_customers_table.php
@@ -19,4 +19,9 @@ return new class extends Migration
             $table->unique(['billable_id', 'billable_type']);
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lemon_squeezy_customers');
+    }
 };

--- a/database/migrations/2023_01_16_000002_create_subscriptions_table.php
+++ b/database/migrations/2023_01_16_000002_create_subscriptions_table.php
@@ -29,4 +29,9 @@ return new class extends Migration
             $table->index(['billable_id', 'billable_type']);
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lemon_squeezy_subscriptions');
+    }
 };


### PR DESCRIPTION
Hello,

I am aware that the use of "down" methods in our migrations is typically [unnecessary](https://laraveldaily.com/post/still-need-migrations-taylor-says-no) these days. However, it is still considered standard practice in Laravel, isn't it? With that in mind, I have submitted a pull request to include it.

Thank you for your great work, 
George