### PR TITLE
Fix billable_id

### DIFF
--- a/database/migrations/2023_01_16_000001_create_customers_table.php
+++ b/database/migrations/2023_01_16_000001_create_customers_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('lemon_squeezy_customers', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('billable_id');
+            $table->string('billable_id');
             $table->string('billable_type');
             $table->string('lemon_squeezy_id')->nullable()->unique();
             $table->timestamp('trial_ends_at')->nullable();

--- a/database/migrations/2023_01_16_000002_create_subscriptions_table.php
+++ b/database/migrations/2023_01_16_000002_create_subscriptions_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('lemon_squeezy_subscriptions', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('billable_id');
+            $table->string('billable_id');
             $table->string('billable_type');
             $table->string('type');
             $table->string('lemon_squeezy_id')->unique();


### PR DESCRIPTION
https://github.com/lmsqueezy/laravel/issues/21


In my project I have uuid for billable entities. So seems it better to use varchar in migrations

In WebhookController it's already int|string type. I tasted it on my project and it works