### PR TITLE
Add support for custom price at checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,18 @@ This will automatically redirect your customer to a Lemon Squeezy checkout where
 > **Note**
 > When creating a checkout for your store, each time you redirect a checkout object or call `url` on the checkout object, an API call to Lemon Squeezy will be made. These calls are expensive and can be time and resource consuming for your app. If you are creating the same session over and over again you may want to cache these urls. 
 
+#### Single Payments with Custom Price
+
+For example, to create a checkout for a single-payment with custom price, use a variant ID of a product variant you want to sell at custom price and create a checkout with custom price using the snippet below:
+
+```php
+use Illuminate\Http\Request;
+ 
+Route::get('/buy', function (Request $request) {
+    return $request->user()->checkout('variant-id')->withCustomPrice(20000);
+});
+```
+
 ### Overlay Widget
 
 Instead of redirecting your customer to a checkout screen, you can also create a checkout button which will render a checkout overlay on your page. To do this, pass the `$checkout` object to a view:

--- a/README.md
+++ b/README.md
@@ -194,17 +194,21 @@ This will automatically redirect your customer to a Lemon Squeezy checkout where
 > **Note**
 > When creating a checkout for your store, each time you redirect a checkout object or call `url` on the checkout object, an API call to Lemon Squeezy will be made. These calls are expensive and can be time and resource consuming for your app. If you are creating the same session over and over again you may want to cache these urls. 
 
-#### Single Payments with Custom Price
+#### Custom Priced Charges
 
-For example, to create a checkout for a single-payment with custom price, use a variant ID of a product variant you want to sell at custom price and create a checkout with custom price using the snippet below:
+You can also overwrite the amount of a product variant by calling the `charge` method on a customer:
 
 ```php
 use Illuminate\Http\Request;
  
 Route::get('/buy', function (Request $request) {
-    return $request->user()->checkout('variant-id')->withCustomPrice(20000);
+    return $request->user()->charge(2500, 'variant-id');
 });
 ```
+
+The amount should be a positive integer in cents.
+
+You'll still need to provide a variant ID but can overwrite the price as you see fit. One thing you can do is create a "generic" product with a specific currency which you can dynamically charge against.
 
 ### Overlay Widget
 

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -34,6 +34,8 @@ class Checkout implements Responsable
 
     private ?DateTimeInterface $expiresAt;
 
+    private ?int $customPrice = null;
+    
     public function __construct(private string $store, private string $variant)
     {
     }
@@ -169,12 +171,20 @@ class Checkout implements Responsable
         return $this;
     }
 
+    public function withCustomPrice(?int $customPrice): self
+    {
+        $this->customPrice = $customPrice;
+
+        return $this;
+    }
+
     public function url(): string
     {
         $response = LemonSqueezy::api('POST', 'checkouts', [
             'data' => [
                 'type' => 'checkouts',
                 'attributes' => [
+                    'custom_price' => $this->customPrice,
                     'checkout_data' => array_merge(
                         array_filter($this->checkoutData, fn ($value) => $value !== ''),
                         ['custom' => $this->custom]

--- a/src/Concerns/ManagesCheckouts.php
+++ b/src/Concerns/ManagesCheckouts.php
@@ -35,6 +35,16 @@ trait ManagesCheckouts
     }
 
     /**
+     * Create a new checkout instance to sell a product with a custom price.
+     */
+    public function charge(int $amount, string $variant, array $options = [], array $custom = [])
+    {
+        return $this->checkout($variant, array_merge($options, [
+            'custom_price' => $amount,
+        ]), $custom);
+    }
+
+    /**
      * Subscribe the customer to a new plan variant.
      */
     public function subscribe(string $variant, string $type = Subscription::DEFAULT_TYPE, array $options = [], array $custom = []): Checkout

--- a/src/Concerns/ManagesCheckouts.php
+++ b/src/Concerns/ManagesCheckouts.php
@@ -30,6 +30,7 @@ trait ManagesCheckouts
             )
             ->withTaxNumber($options['tax_number'] ?? (string) $this->lemonSqueezyTaxNumber())
             ->withDiscountCode($options['discount_code'] ?? '')
+            ->withCustomPrice($options['custom_price'] ?? null)
             ->withCustomData($custom);
     }
 


### PR DESCRIPTION
This will add support for custom price during the checkout by providing the `custom_price` key to options array.