### PR TITLE
Add support for custom name, description at checkout. And receipt_thank_you_note.

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,25 @@ Route::get('/buy', function (Request $request) {
 });
 ```
 
+### Product Details
+
+You can overwrite additional data for product checkouts with the `withProductName` and `withDescription` methods:
+
+```php
+$request->user()->checkout('variant-id')
+    ->withProductName('Ebook')
+    ->withDescription('A thrilling novel!');
+```
+
+### Receipt Thank You
+
+Additionally, you can customize the thank you note for the order receipt email.
+
+```php
+$request->user()->checkout('variant-id')
+    ->withThankYouNote('Thanks for your purchase!');
+```
+
 ### Redirects After Purchase
 
 To redirect customers back to your app after purchase, you may use the `redirectTo` method:

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -30,15 +30,17 @@ class Checkout implements Responsable
 
     private array $custom = [];
 
+    private ?string $productName = null;
+
+    private ?string $description = null;
+
+    private ?string $thankYouNote = null;
+
     private ?string $redirectUrl;
 
     private ?DateTimeInterface $expiresAt;
 
     private ?int $customPrice = null;
-
-    private ?string $description = null; // Added new description property  = null
-    private ?string $productName = null; // Added new description property  = null
-    private ?string $thankYouNote = null; // Added new description property  = null
 
     public function __construct(private string $store, private string $variant)
     {
@@ -59,27 +61,6 @@ class Checkout implements Responsable
     public function withoutLogo(): self
     {
         $this->logo = false;
-
-        return $this;
-    }
-
-    public function withDescription(string $description): self //added
-    {
-        $this->description = $description;
-
-        return $this;
-    }
-
-    public function withproductName(string $productName): self //added 
-    {
-        $this->productName = $productName;
-
-        return $this;
-    }
-
-    public function withthankYouNote(string $thankYouNote): self //added thankYouNote
-    {
-        $this->thankYouNote = $thankYouNote;
 
         return $this;
     }
@@ -182,6 +163,27 @@ class Checkout implements Responsable
         return $this;
     }
 
+    public function withProductName(string $productName): self
+    {
+        $this->productName = $productName;
+
+        return $this;
+    }
+
+    public function withDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function withThankYouNote(string $thankYouNote): self
+    {
+        $this->thankYouNote = $thankYouNote;
+
+        return $this;
+    }
+
     public function redirectTo(string $url): self
     {
         $this->redirectUrl = $url;
@@ -226,13 +228,12 @@ class Checkout implements Responsable
                     ], function ($value) {
                         return ! is_null($value);
                     }),
-                    'product_options' => [
-                        'name' => $this->productName,  // Added name field to product_options
-                        'description' => $this->description,  // Added description field to product_options
-                        'receipt_thank_you_note' => $this->thankYouNote, // Added thank you note at email response field to product_options
-                        'redirect_url' => $this->redirectUrl ?? config('lemon-squeezy.redirect_url'), 
-                  
-                    ],
+                    'product_options' => array_filter([
+                        'name' => $this->productName,
+                        'description' => $this->description,
+                        'receipt_thank_you_note' => $this->thankYouNote,
+                        'redirect_url' => $this->redirectUrl ?? config('lemon-squeezy.redirect_url'),
+                    ]),
                     'expires_at' => isset($this->expiresAt) ? $this->expiresAt->format(DateTimeInterface::ATOM) : null,
                 ],
                 'relationships' => [
@@ -251,7 +252,7 @@ class Checkout implements Responsable
                 ],
             ],
         ]);
-        //dd($response['data']['attributes']['product_options']['receipt_thank_you_note']);
+
         return $response['data']['attributes']['url'];
     }
 

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -36,6 +36,10 @@ class Checkout implements Responsable
 
     private ?int $customPrice = null;
 
+    private ?string $description = null; // Added new description property  = null
+    private ?string $productName = null; // Added new description property  = null
+    private ?string $thankYouNote = null; // Added new description property  = null
+
     public function __construct(private string $store, private string $variant)
     {
     }
@@ -55,6 +59,27 @@ class Checkout implements Responsable
     public function withoutLogo(): self
     {
         $this->logo = false;
+
+        return $this;
+    }
+
+    public function withDescription(string $description): self //added
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function withproductName(string $productName): self //added 
+    {
+        $this->productName = $productName;
+
+        return $this;
+    }
+
+    public function withthankYouNote(string $thankYouNote): self //added thankYouNote
+    {
+        $this->thankYouNote = $thankYouNote;
 
         return $this;
     }
@@ -202,7 +227,11 @@ class Checkout implements Responsable
                         return ! is_null($value);
                     }),
                     'product_options' => [
-                        'redirect_url' => $this->redirectUrl ?? config('lemon-squeezy.redirect_url'),
+                        'name' => $this->productName,  // Added name field to product_options
+                        'description' => $this->description,  // Added description field to product_options
+                        'receipt_thank_you_note' => $this->thankYouNote, // Added thank you note at email response field to product_options
+                        'redirect_url' => $this->redirectUrl ?? config('lemon-squeezy.redirect_url'), 
+                  
                     ],
                     'expires_at' => isset($this->expiresAt) ? $this->expiresAt->format(DateTimeInterface::ATOM) : null,
                 ],
@@ -222,7 +251,7 @@ class Checkout implements Responsable
                 ],
             ],
         ]);
-
+        //dd($response['data']['attributes']['product_options']['receipt_thank_you_note']);
         return $response['data']['attributes']['url'];
     }
 


### PR DESCRIPTION
This will add support for custom name and decription during the checkout by providing the $productName and $description.

name - A custom name for the product
description - A custom description for the product
receipt_thank_you_note - A custom thank you note to use for the order receipt email

And still didnt get to know how to make this receipt_thank_you_note work.
Do you have any suggestion how make this work?