### PR TITLE
Use `hash_equals` when validating webhook signature

### DIFF
--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -32,6 +32,6 @@ class VerifyWebhookSignature
     {
         $hash = hash_hmac('sha256', $payload, config('lemon-squeezy.signing_secret'));
 
-        return $hash !== $signature;
+        return !hash_equals($hash, $signature);
     }
 }

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -32,6 +32,6 @@ class VerifyWebhookSignature
     {
         $hash = hash_hmac('sha256', $payload, config('lemon-squeezy.signing_secret'));
 
-        return !hash_equals($hash, $signature);
+        return ! hash_equals($hash, $signature);
     }
 }


### PR DESCRIPTION
The use of `!==` over `hash_equals` was bothering me, not sure if the validation needs a timing-safe string comparison but better safe than sorry. It is also the way Lemon Squeezy uses in [their example](https://docs.lemonsqueezy.com/guides/developer-guide/webhooks#signing-and-validating-webhook-requests):

```php
$secret    = '[SIGNING_SECRET]'; // from your webhook settings
$payload   = file_get_contents('php://input');
$hash      = hash_hmac('sha256', $payload, $secret);
$signature = $_SERVER['HTTP_X_SIGNATURE'] ?? '';

if (!hash_equals($hash, $signature)) {
    throw new Exception('Invalid signature.');
}
```