### PR TITLE
Grammer typo: Wrong preposition 

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ When a user clicks this button, it'll trigger the Lemon Squeezy checkout overlay
 </x-lemon-button>
 ```
 
-If you're checking out subscriptions, and you don't want to to show the "You will be charged..." text, you may disable this by calling the `withoutSubscriptionPreview` method on the checkout object:
+If you're checking out subscriptions, and you don't want to show the "You will be charged..." text, you may disable this by calling the `withoutSubscriptionPreview` method on the checkout object:
 
 ```php
 $request->user()->subscribe('variant-id')


### PR DESCRIPTION
Removed extra preposition from a sentence.


Before: `If you're checking out subscriptions, and you don't want **to to** show the "You will be charged..." text, you may disable this by calling the `withoutSubscriptionPreview` method on the checkout object:`

After: `If you're checking out subscriptions, and you don't want **to** show the "You will be charged..." text, you may disable this by calling the `withoutSubscriptionPreview` method on the checkout object:`

