### PR TITLE
Fix missing lemon_squeezy_id if billable was on generic trial

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -109,6 +109,11 @@ final class WebhookController extends Controller
             $billable->customer->update(['trial_ends_at' => null]);
         }
 
+        // Set the billable's lemon squeezy id if it was on generic trial at the model level
+        if (is_null($billable->customer->lemon_squeezy_id)) {
+            $billable->customer->update(['lemon_squeezy_id' => $attributes['customer_id']]);
+        }
+
         SubscriptionCreated::dispatch($billable, $subscription, $payload);
     }
 


### PR DESCRIPTION
Hi there!

I've encountered a small issue in my app.

During user registration, I initiate a generic trial with:

```php
$user->createAsCustomer([
    'trial_ends_at' => now()->addDays(7)->endOfDay(),
]);
```

After this process, the Customer appears as follows:

```php
LemonSqueezy\Laravel\Customer {#2544
    id: 9,
    billable_id: 16,
    billable_type: "App\Models\User",
    lemon_squeezy_id: null,
    trial_ends_at: "2023-11-07 23:59:59",
    created_at: "2023-10-31 18:29:25",
    updated_at: "2023-10-31 18:29:25",
}
```

When a user decides to subscribe, the app receives webhooks from Lemon Squeezy. One of these events is `subscription_created` which sets `trial_ends_at` to `null` but didn't update `lemon_squeezy_id`.

