### PR TITLE
added withQuantity method to checkout

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -42,6 +42,8 @@ class Checkout implements Responsable
 
     private ?int $customPrice = null;
 
+    private int $quantity = 1;
+
     public function __construct(private string $store, private string $variant)
     {
     }
@@ -141,6 +143,16 @@ class Checkout implements Responsable
     public function withDiscountCode(string $discountCode): self
     {
         $this->checkoutData['discount_code'] = $discountCode;
+
+        return $this;
+    }
+
+    public function withQuantity(int $quantity): self
+    {
+        $this->checkoutData['variant_quantities'] = [
+            'variant_id' => $this->variant,
+            'quantity' => $quantity,
+        ];
 
         return $this;
     }

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -150,8 +150,10 @@ class Checkout implements Responsable
     public function withQuantity(int $quantity): self
     {
         $this->checkoutData['variant_quantities'] = [
-            'variant_id' => $this->variant,
-            'quantity' => $quantity,
+            [
+                'variant_id' => (int) $this->variant,
+                'quantity' => $quantity,
+            ],
         ];
 
         return $this;

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -98,3 +98,18 @@ it('can include prefilled fields and custom data', function () {
     expect($checkout->url())
         ->toBe('https://lemon.lemonsqueezy.com/checkout/buy/variant_123');
 });
+
+it('can include quantities', function () {
+    $checkout = Checkout::make('store_24398', 'variant_123')
+        ->withName('John Doe')
+        ->withQuantity(2);
+
+    Http::fake([
+        'api.lemonsqueezy.com/v1/checkouts' => Http::response([
+            'data' => ['attributes' => ['url' => 'https://lemon.lemonsqueezy.com/checkout/buy/variant_123']],
+        ]),
+    ]);
+
+    expect($checkout->url())
+        ->toBe('https://lemon.lemonsqueezy.com/checkout/buy/variant_123');
+});


### PR DESCRIPTION
added option to set quantities on checkout defaults to 1.

This allows usage:

```php
$request->user()->checkout('variant-id')->withQuantity(5)
```

This added the array key to the payload

```php
['variant_quantities'] = [
    [
         'variant_id' => (int) $this->variant,
          'quantity' => $quantity,
    ],
]
 ```