### PR TITLE
Use Order::STATUS_PAID instead of static::STATUS_PAID

### DIFF
--- a/src/Concerns/ManagesOrders.php
+++ b/src/Concerns/ManagesOrders.php
@@ -4,6 +4,7 @@ namespace LemonSqueezy\Laravel\Concerns;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use LemonSqueezy\Laravel\LemonSqueezy;
+use LemonSqueezy\Laravel\Order;
 
 trait ManagesOrders
 {
@@ -20,7 +21,7 @@ trait ManagesOrders
      */
     public function hasPurchasedProduct(string $productId): bool
     {
-        return $this->orders()->where('product_id', $productId)->where('status', static::STATUS_PAID)->exists();
+        return $this->orders()->where('product_id', $productId)->where('status', Order::STATUS_PAID)->exists();
     }
 
     /**
@@ -28,6 +29,6 @@ trait ManagesOrders
      */
     public function hasPurchasedVariant(string $variantId): bool
     {
-        return $this->orders()->where('variant_id', $variantId)->where('status', static::STATUS_PAID)->exists();
+        return $this->orders()->where('variant_id', $variantId)->where('status', Order::STATUS_PAID)->exists();
     }
 }


### PR DESCRIPTION
This fixes the following error thrown by this adapter: `Undefined constant App\Models\User::STATUS_PAID`