### PR TITLE
Fix order webhook handler

### DIFF
--- a/database/migrations/2023_01_16_000003_create_orders_table.php
+++ b/database/migrations/2023_01_16_000003_create_orders_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
             $table->string('billable_type');
             $table->string('lemon_squeezy_id')->unique();
             $table->string('customer_id');
+            $table->uuid('identifier')->unique();
             $table->string('product_id');
             $table->string('variant_id');
             $table->integer('order_number')->unique();

--- a/database/migrations/2023_01_16_000003_create_orders_table.php
+++ b/database/migrations/2023_01_16_000003_create_orders_table.php
@@ -14,7 +14,6 @@ return new class extends Migration
             $table->string('billable_type');
             $table->string('lemon_squeezy_id')->unique();
             $table->string('customer_id');
-            $table->uuid('identifier')->unique();
             $table->string('product_id');
             $table->string('variant_id');
             $table->integer('order_number')->unique();
@@ -23,7 +22,7 @@ return new class extends Migration
             $table->integer('discount_total');
             $table->integer('tax');
             $table->integer('total');
-            $table->string('tax_name');
+            $table->string('tax_name')->nullable();
             $table->string('status');
             $table->string('receipt_url')->nullable();
             $table->boolean('refunded');

--- a/src/Concerns/ManagesOrders.php
+++ b/src/Concerns/ManagesOrders.php
@@ -2,9 +2,8 @@
 
 namespace LemonSqueezy\Laravel\Concerns;
 
-use LemonSqueezy\Laravel\Order;
-use LemonSqueezy\Laravel\LemonSqueezy;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use LemonSqueezy\Laravel\LemonSqueezy;
 
 trait ManagesOrders
 {
@@ -21,7 +20,7 @@ trait ManagesOrders
      */
     public function hasPurchasedProduct(string $productId): bool
     {
-        return $this->orders()->where('product_id', $productId)->where('status', Order::STATUS_PAID)->exists();
+        return $this->orders()->where('product_id', $productId)->where('status', static::STATUS_PAID)->exists();
     }
 
     /**
@@ -29,6 +28,6 @@ trait ManagesOrders
      */
     public function hasPurchasedVariant(string $variantId): bool
     {
-        return $this->orders()->where('variant_id', $variantId)->where('status', Order::STATUS_PAID)->exists();
+        return $this->orders()->where('variant_id', $variantId)->where('status', static::STATUS_PAID)->exists();
     }
 }

--- a/src/Concerns/ManagesOrders.php
+++ b/src/Concerns/ManagesOrders.php
@@ -2,8 +2,9 @@
 
 namespace LemonSqueezy\Laravel\Concerns;
 
-use Illuminate\Database\Eloquent\Relations\MorphMany;
+use LemonSqueezy\Laravel\Order;
 use LemonSqueezy\Laravel\LemonSqueezy;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait ManagesOrders
 {
@@ -20,7 +21,7 @@ trait ManagesOrders
      */
     public function hasPurchasedProduct(string $productId): bool
     {
-        return $this->orders()->where('product_id', $productId)->where('status', static::STATUS_PAID)->exists();
+        return $this->orders()->where('product_id', $productId)->where('status', Order::STATUS_PAID)->exists();
     }
 
     /**
@@ -28,6 +29,6 @@ trait ManagesOrders
      */
     public function hasPurchasedVariant(string $variantId): bool
     {
-        return $this->orders()->where('variant_id', $variantId)->where('status', static::STATUS_PAID)->exists();
+        return $this->orders()->where('variant_id', $variantId)->where('status', Order::STATUS_PAID)->exists();
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -79,13 +79,13 @@ final class WebhookController extends Controller
         // Todo v2: Remove this check
         if (Schema::hasTable((new LemonSqueezy::$orderModel)->getTable())) {
             $attributes = $payload['data']['attributes'];
-            $order = $payload['data']['attributes']['first_order_item'];
+            firstOrderItem = $payload['data']['attributes']['first_order_item'];
 
             $order = $billable->orders()->create([
                 'lemon_squeezy_id' => $payload['data']['id'],
                 'customer_id' => $attributes['customer_id'],
-                'product_id' => $order['product_id'],
-                'variant_id' => $order['variant_id'],
+                'product_id' => firstOrderItem['product_id'],
+                'variant_id' => firstOrderItem['variant_id'],
                 'identifier' => $attributes['identifier'],
                 'order_number' => $attributes['order_number'],
                 'currency' => $attributes['currency'],

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -79,12 +79,13 @@ final class WebhookController extends Controller
         // Todo v2: Remove this check
         if (Schema::hasTable((new LemonSqueezy::$orderModel)->getTable())) {
             $attributes = $payload['data']['attributes'];
+            $order = $payload['data']['attributes']['first_order_item'];
 
             $order = $billable->orders()->create([
                 'lemon_squeezy_id' => $payload['data']['id'],
                 'customer_id' => $attributes['customer_id'],
-                'product_id' => $attributes['product_id'],
-                'variant_id' => $attributes['variant_id'],
+                'product_id' => $order['product_id'],
+                'variant_id' => $order['variant_id'],
                 'order_number' => $attributes['order_number'],
                 'currency' => $attributes['currency'],
                 'subtotal' => $attributes['subtotal'],

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -79,13 +79,12 @@ final class WebhookController extends Controller
         // Todo v2: Remove this check
         if (Schema::hasTable((new LemonSqueezy::$orderModel)->getTable())) {
             $attributes = $payload['data']['attributes'];
-            firstOrderItem = $payload['data']['attributes']['first_order_item'];
 
             $order = $billable->orders()->create([
                 'lemon_squeezy_id' => $payload['data']['id'],
                 'customer_id' => $attributes['customer_id'],
-                'product_id' => firstOrderItem['product_id'],
-                'variant_id' => firstOrderItem['variant_id'],
+                'product_id' => firstOrderItem['first_order_item']['product_id'],
+                'variant_id' => firstOrderItem['first_order_item']['variant_id'],
                 'identifier' => $attributes['identifier'],
                 'order_number' => $attributes['order_number'],
                 'currency' => $attributes['currency'],

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -83,8 +83,8 @@ final class WebhookController extends Controller
             $order = $billable->orders()->create([
                 'lemon_squeezy_id' => $payload['data']['id'],
                 'customer_id' => $attributes['customer_id'],
-                'product_id' => firstOrderItem['first_order_item']['product_id'],
-                'variant_id' => firstOrderItem['first_order_item']['variant_id'],
+                'product_id' => $attributes['first_order_item']['product_id'],
+                'variant_id' => $attributes['first_order_item']['variant_id'],
                 'identifier' => $attributes['identifier'],
                 'order_number' => $attributes['order_number'],
                 'currency' => $attributes['currency'],

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -86,6 +86,7 @@ final class WebhookController extends Controller
                 'customer_id' => $attributes['customer_id'],
                 'product_id' => $order['product_id'],
                 'variant_id' => $order['variant_id'],
+                'identifier' => $attributes['identifier'],
                 'order_number' => $attributes['order_number'],
                 'currency' => $attributes['currency'],
                 'subtotal' => $attributes['subtotal'],

--- a/src/Order.php
+++ b/src/Order.php
@@ -179,8 +179,8 @@ class Order extends Model
     {
         $this->update([
             'customer_id' => $attributes['customer_id'],
-            'product_id' => $attributes['product_id'],
-            'variant_id' => $attributes['variant_id'],
+            'product_id' => $attributes['first_order_item']['product_id'],
+            'variant_id' => $attributes['first_order_item']['variant_id'],
             'order_number' => $attributes['order_number'],
             'currency' => $attributes['currency'],
             'subtotal' => $attributes['subtotal'],


### PR DESCRIPTION
This PR contains the following fixes:
* The fix from #61 (changing `static::` to `Order::`)
* Populate the the `identifier` field from the payload
  * I was getting a db error because it was never filled from the webhook handler
* Making `tax_name` a nullable field because it was coming back "null" for me
* Retrieving order details from `$payload['data']['attributes']['first_order_item']`
  * Not sure if this is the right way, but it's the only thing in my webhook payload that contained "product_id" and "variant_id"
  * Maybe the payloads are different if the product has a variant or not, but in my case, I can't create a "checkout" link without a variant, so I had to create a variant

I didn't add any tests because there's no precedent for webhook tests. Might be something to consider: tests with payload stubs to simulate handling new orders and subscriptions...
  
I do not intend for this PR to be merged (unless you want). This is more like a log of what got it all working for me locally for your reference.

Thanks for all your hard work on this!
