### PR TITLE
fix: Missing Illuminate Builder import in Order model

### DIFF
--- a/src/Order.php
+++ b/src/Order.php
@@ -3,6 +3,7 @@
 namespace LemonSqueezy\Laravel;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;


### PR DESCRIPTION
The Order model is missing an import for the `Illuminate\Database\Eloquent\Builder`, which causes the scopes to fail with the error: `Argument #1 ($query) must be of type LemonSqueezy\Laravel\Builder, Illuminate\Database\Eloquent\Builder given`

This PR adds the missing import.