### PR TITLE
Add configurable table names

### DIFF
--- a/config/lemon-squeezy.php
+++ b/config/lemon-squeezy.php
@@ -80,4 +80,20 @@ return [
 
     'currency_locale' => env('LEMON_SQUEEZY_CURRENCY_LOCALE', 'en'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Table Names
+    |--------------------------------------------------------------------------
+    |
+    | The table names used by Lemon Squeezy to store orders, customers, and
+    | subscriptions. These values are used by the package's eloquent models
+    | and migrations.
+    |
+    */
+
+    'tables' => [
+        'orders'        => 'lemon_squeezy_orders',
+        'customers'     => 'lemon_squeezy_customers',
+        'subscriptions' => 'lemon_squeezy_subscriptions'
+    ]
 ];

--- a/database/migrations/2023_01_16_000001_create_customers_table.php
+++ b/database/migrations/2023_01_16_000001_create_customers_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('lemon_squeezy_customers', function (Blueprint $table) {
+        Schema::create(config('lemon-squeezy.tables.customers', 'lemon_squeezy_customers'), function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('billable_id');
             $table->string('billable_type');
@@ -22,6 +22,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('lemon_squeezy_customers');
+        Schema::dropIfExists(config('lemon-squeezy.tables.customers', 'lemon_squeezy_customers'));
     }
 };

--- a/database/migrations/2023_01_16_000002_create_subscriptions_table.php
+++ b/database/migrations/2023_01_16_000002_create_subscriptions_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('lemon_squeezy_subscriptions', function (Blueprint $table) {
+        Schema::create(config('lemon-squeezy.tables.subscriptions', 'lemon_squeezy_subscriptions'), function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('billable_id');
             $table->string('billable_type');
@@ -32,6 +32,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('lemon_squeezy_subscriptions');
+        Schema::dropIfExists(config('lemon-squeezy.tables.subscriptions', 'lemon_squeezy_subscriptions'));
     }
 };

--- a/database/migrations/2023_01_16_000003_create_orders_table.php
+++ b/database/migrations/2023_01_16_000003_create_orders_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('lemon_squeezy_orders', function (Blueprint $table) {
+        Schema::create(config('lemon-squeezy.tables.orders', 'lemon_squeezy_orders'), function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('billable_id');
             $table->string('billable_type');
@@ -37,6 +37,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('lemon_squeezy_orders');
+        Schema::dropIfExists(config('lemon-squeezy.tables.orders', 'lemon_squeezy_orders'));
     }
 };

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -15,11 +15,15 @@ class Customer extends Model
     use HasFactory;
 
     /**
-     * The table associated with the model.
+     * Get the table associated with the model.
      *
-     * @var string
+     * @return string
      */
-    protected $table = 'lemon_squeezy_customers';
+
+    public function getTable()
+    {
+        return config('lemon-squeezy.tables.customers', 'lemon_squeezy_customers');
+    }
 
     /**
      * The attributes that are not mass assignable.

--- a/src/Order.php
+++ b/src/Order.php
@@ -25,11 +25,14 @@ class Order extends Model
     const STATUS_REFUNDED = 'refunded';
 
     /**
-     * The table associated with the model.
+     * Get the table associated with the model.
      *
-     * @var string
+     * @return string
      */
-    protected $table = 'lemon_squeezy_orders';
+    public function getTable()
+    {
+        return config('lemon-squeezy.tables.orders', 'lemon_squeezy_orders');
+    }
 
     /**
      * The attributes that are not mass assignable.

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -37,11 +37,14 @@ class Subscription extends Model
     const DEFAULT_TYPE = 'default';
 
     /**
-     * The table associated with the model.
+     * Get the table associated with the model.
      *
-     * @var string
+     * @return string
      */
-    protected $table = 'lemon_squeezy_subscriptions';
+    public function getTable()
+    {
+        return config('lemon-squeezy.tables.subscriptions', 'lemon_squeezy_subscriptions');
+    }
 
     /**
      * The attributes that are not mass assignable.


### PR DESCRIPTION
This pull request adds configurable table names to the config file. Created because I needed to move the tables to a different schema and wasn't sure how to override the package model's getTable methods.

For each config usage I set a default of the original table name, therefore this change should be backwards compatible even if the end user already published an older version of the config.