### PR TITLE
Closes #77 Listen command throws error

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -266,7 +266,7 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
                         'license_key_created',
                         'license_key_updated',
                     ],
-                    'secret' => config('lemon-squeezy.signing_secret') ?: Str::limit(Hash::make(config('lemon-squeezy.api_key')), 32, '')
+                    'secret' => config('lemon-squeezy.signing_secret') ?: Str::random(32),
                 ],
                 'relationships' => [
                     'store' => [

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Http\Client\Response;
 use Illuminate\Process\InvokedProcess;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Validator;
@@ -85,15 +86,11 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
                 'string',
                 'in:expose,ngrok,test',
             ],
-            'signing_secret' => [
-                'required',
-            ],
             'store' => [
                 'required',
             ],
         ], [
             'api_key.required' => 'The LEMON_SQUEEZY_API_KEY environment variable is required.',
-            'signing_secret.required' => 'The LEMON_SQUEEZY_SIGNING_SECRET environment variable is required.',
             'store.required' => 'The LEMON_SQUEEZY_STORE environment variable is required.',
         ])->validate();
     }
@@ -269,7 +266,7 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
                         'license_key_created',
                         'license_key_updated',
                     ],
-                    'secret' => config('lemon-squeezy.signing_secret'),
+                    'secret' => config('lemon-squeezy.signing_secret') ?: Str::limit(Hash::make(config('lemon-squeezy.api_key')), 32, '')
                 ],
                 'relationships' => [
                     'store' => [


### PR DESCRIPTION
Handles when `LEMON_SQUEEZY_SIGNING_SECRET` is not set in the env, by falling back to a hash of the `LEMON_SQUEEZY_API_KEY`