### PR TITLE
Fix Tests on Laravel 11 and exit codes

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -67,7 +67,12 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
     public function handle()
     {
         $this->validateArguments();
-        $this->handleEnvironment();
+
+        $errorCode = $this->handleEnvironment();
+        if ($errorCode !== null) {
+            return $errorCode;
+        }
+
         $this->handleCleanup();
         $this->handleService();
 
@@ -94,19 +99,21 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
         ])->validate();
     }
 
-    protected function handleEnvironment(): void
+    protected function handleEnvironment(): int|null
     {
         if ($this->argument('service') === 'test') {
             info('lmsqueezy:listen is using the test service.');
 
-            exit(Command::SUCCESS);
+            return Command::SUCCESS;
         }
 
         if (! App::environment('local')) {
             error('lmsqueezy:listen can only be used in local environment.');
 
-            exit(Command::FAILURE);
+            return Command::FAILURE;
         }
+
+        return null;
     }
 
     protected function handleCleanup(): void

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -99,7 +99,7 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
         ])->validate();
     }
 
-    protected function handleEnvironment(): int|null
+    protected function handleEnvironment(): ?int
     {
         if ($this->argument('service') === 'test') {
             info('lmsqueezy:listen is using the test service.');

--- a/tests/Feature/Commands/ListenCommandTest.php
+++ b/tests/Feature/Commands/ListenCommandTest.php
@@ -16,5 +16,6 @@ it('can call the listen command', function () {
 
 it('can validate services', function () {
     $this->expectException(ValidationException::class);
-    expect(Artisan::call('lmsqueezy:listen', ['service' => 'invalid']))->toEqual(Command::FAILURE);
+
+    Artisan::call('lmsqueezy:listen', ['service' => 'invalid']);
 });

--- a/tests/Feature/Commands/ListenCommandTest.php
+++ b/tests/Feature/Commands/ListenCommandTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Validation\ValidationException;
 
 it('can call the listen command', function () {
     config()->set([
@@ -14,5 +15,6 @@ it('can call the listen command', function () {
 });
 
 it('can validate services', function () {
+    $this->expectException(ValidationException::class);
     expect(Artisan::call('lmsqueezy:listen', ['service' => 'invalid']))->toEqual(Command::FAILURE);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,10 +3,13 @@
 namespace Tests;
 
 use LemonSqueezy\Laravel\LemonSqueezyServiceProvider;
+use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 class TestCase extends OrchestraTestCase
 {
+    use WithLaravelMigrations;
+
     protected function getPackageProviders($app)
     {
         return [
@@ -17,10 +20,5 @@ class TestCase extends OrchestraTestCase
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
-    }
-
-    protected function defineDatabaseMigrations()
-    {
-        $this->loadLaravelMigrations();
     }
 }


### PR DESCRIPTION
This PR fixes the following issues:

1. Exit Codes were not being properly reported to GitHub Actions due to exit() calls on a command execute from the tests
2. Changes to TestCase to execute Laravel migrations on Laravel 11