### PR TITLE
Add command to list products and variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ public function register(): void
 
 Now you'll rely on your own migrations rather than the package one. Please note though that you're now responsible as well for keeping these in sync withe package one manually whenever you upgrade the package.
 
+## Commands
+
+Below you'll find a list of commands you can run to retrieve info from Lemon Squeezy:
+
+Command | Description
+--- | ---
+`php artisan lmsqueezy:products` | List all available products with their variants and prices
+`php artisan lmsqueezy:products 12345` | List a specific product by its ID with its variants and prices
+
+
 ## Checkouts
 
 With this package, you can easily create checkouts for your customers.

--- a/src/Console/ListProductsCommand.php
+++ b/src/Console/ListProductsCommand.php
@@ -100,7 +100,8 @@ class ListProductsCommand extends Command
         $this->displayProduct($product);
 
         $variants = collect($response->json('included'))
-            ->filter(fn ($item) => $item['type'] === 'variants');
+            ->filter(fn ($item) => $item['type'] === 'variants')
+            ->sortBy('sort');
 
         $variants->each(fn (array $variant) => $this->displayVariant(
             $variant,
@@ -140,7 +141,8 @@ class ListProductsCommand extends Command
             $variantIds = collect(Arr::get($product, 'relationships.variants.data'))->pluck('id');
             $variants = collect($productsResponse->json('included'))
                 ->filter(fn ($item) => $item['type'] === 'variants')
-                ->filter(fn ($item) => $variantIds->contains($item['id']));
+                ->filter(fn ($item) => $variantIds->contains($item['id']))
+                ->sortBy('sort');
 
             $variants->each(fn ($variant) => $this->displayVariant(
                 $variant,

--- a/src/Console/ListProductsCommand.php
+++ b/src/Console/ListProductsCommand.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use LemonSqueezy\Laravel\LemonSqueezy;
+
+use function Laravel\Prompts\spin;
+
+class ListProductsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'lmsqueezy:products
+                            {product? : The ID of the product to list variants for.}
+    ';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Lists all products and their variants.';
+
+    public function handle(): int
+    {
+        $storeResponse = spin(fn () => $this->fetchStore(), '🍋 Fetching store information...');
+        $store = $storeResponse->json('data.attributes');
+
+        $productId = $this->argument('product');
+
+        if ($productId) {
+            return $this->handleProduct($store, $productId);
+        }
+
+        return $this->handleProducts($store);
+    }
+
+    private function fetchStore(): Response
+    {
+        return LemonSqueezy::api('GET', sprintf('stores/%s', config('lemon-squeezy.store')));
+    }
+
+    private function handleProduct(array $store, string $productId): int
+    {
+        $response = spin(
+            fn () => LemonSqueezy::api(
+                'GET',
+                sprintf('products/%s', $productId),
+                ['include' => 'variants']
+            ),
+            '🍋 Fetching product information...'
+        );
+
+        $product = $response->json('data');
+
+        $this->newLine();
+        $this->displayTitle();
+        $this->newLine();
+
+        $this->displayProduct($product);
+
+        $variants = collect($response->json('included'))
+            ->filter(fn ($item) => $item['type'] === 'variants');
+
+        $variants->each(fn (array $variant) => $this->displayVariant(
+            $variant,
+            Arr::get($store, 'currency'),
+            $variants->count() > 1
+        ));
+
+        $this->newLine();
+
+        return Command::SUCCESS;
+    }
+
+    private function handleProducts(array $store): int
+    {
+        $productsResponse = spin(
+            fn () => LemonSqueezy::api(
+                'GET',
+                'products',
+                [
+                    'include' => 'variants',
+                    'filter[store_id]' => config('lemon-squeezy.store_id'),
+                    'page[size]' => 100,
+                ]
+            ),
+            '🍋 Fetching products information...',
+        );
+
+        $products = collect($productsResponse->json('data'));
+
+        $this->newLine();
+        $this->displayTitle();
+        $this->newLine();
+
+        $products->each(function ($product) use ($productsResponse, $store) {
+            $this->displayProduct($product);
+
+            $variantIds = collect(Arr::get($product, 'relationships.variants.data'))->pluck('id');
+            $variants = collect($productsResponse->json('included'))
+                ->filter(fn ($item) => $item['type'] === 'variants')
+                ->filter(fn ($item) => $variantIds->contains($item['id']));
+
+            $variants->each(fn ($variant) => $this->displayVariant(
+                $variant,
+                Arr::get($store, 'currency'),
+                $variants->count() > 1
+            ));
+
+            $this->newLine();
+        });
+
+        return Command::SUCCESS;
+    }
+
+    private function displayTitle(): void
+    {
+        $this->components->twoColumnDetail('<fg=gray>Product/Variant</>', '<fg=gray>ID</>');
+    }
+
+    private function displayProduct(array $product): void
+    {
+        $this->components->twoColumnDetail(
+            sprintf('<fg=green;options=bold>%s</>', Arr::get($product, 'attributes.name')),
+            Arr::get($product, 'id')
+        );
+    }
+
+    private function displayVariant(array $variant, string $currency, bool $hidePending = false): void
+    {
+        if (Arr::get($variant, 'attributes.status') === 'pending' && $hidePending) {
+            return;
+        }
+
+        $name = Arr::get($variant, 'attributes.name');
+
+        $price = LemonSqueezy::formatAmount(
+            Arr::get($variant, 'attributes.price'),
+            $currency,
+        );
+
+        $id = Arr::get($variant, 'id');
+
+        $this->components->twoColumnDetail(sprintf('%s <fg=gray>%s</>', $name, $price), $id);
+    }
+}

--- a/src/Console/ListProductsCommand.php
+++ b/src/Console/ListProductsCommand.php
@@ -31,7 +31,7 @@ class ListProductsCommand extends Command
 
     public function handle(): int
     {
-        if (!$this->validate()) {
+        if (! $this->validate()) {
             return Command::FAILURE;
         }
 

--- a/src/Console/ListProductsCommand.php
+++ b/src/Console/ListProductsCommand.php
@@ -56,6 +56,9 @@ class ListProductsCommand extends Command
             'store' => [
                 'required',
             ],
+        ], [
+            'api_key.required' => 'Lemon Squeezy API key not set. You can add it to your .env file as LEMON_SQUEEZY_API_KEY.',
+            'store.required' => 'Lemon Squeezy store ID not set. You can add it to your .env file as LEMON_SQUEEZY_STORE.',
         ]);
 
         if ($validator->passes()) {
@@ -64,12 +67,8 @@ class ListProductsCommand extends Command
 
         $this->newLine();
 
-        if ($validator->errors()->has('api_key')) {
-            error('Lemon Squeezy API key not set. You can add it to your .env file as LEMON_SQUEEZY_API_KEY.');
-        }
-
-        if ($validator->errors()->has('store')) {
-            error('Lemon Squeezy store ID not set. You can add it to your .env file as LEMON_SQUEEZY_STORE.');
+        foreach ($validator->errors()->all() as $error) {
+            error($error);
         }
 
         return false;

--- a/src/LemonSqueezyServiceProvider.php
+++ b/src/LemonSqueezyServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use LemonSqueezy\Laravel\Console\ListenCommand;
+use LemonSqueezy\Laravel\Console\ListProductsCommand;
 use LemonSqueezy\Laravel\Http\Controllers\WebhookController;
 
 class LemonSqueezyServiceProvider extends ServiceProvider
@@ -86,6 +87,7 @@ class LemonSqueezyServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 ListenCommand::class,
+                ListProductsCommand::class,
             ]);
         }
     }

--- a/tests/Feature/Commands/ListProductsCommandTest.php
+++ b/tests/Feature/Commands/ListProductsCommandTest.php
@@ -120,3 +120,17 @@ it('can query a specific product', function () {
         ->expectsOutputToContain('Fake Variant €9.99')
         ->assertSuccessful();
 });
+
+it('fails when api key is missing', function () {
+    config()->set('lemon-squeezy.api_key', null);
+
+    $this->artisan('lmsqueezy:products')
+        ->expectsOutputToContain('Lemon Squeezy API key not set. You can add it to your .env file as LEMON_SQUEEZY_API_KEY.');
+});
+
+it('fails when store is missing', function () {
+    config()->set('lemon-squeezy.store', null);
+
+    $this->artisan('lmsqueezy:products')
+        ->expectsOutputToContain('Lemon Squeezy store ID not set. You can add it to your .env file as LEMON_SQUEEZY_STORE.');
+});

--- a/tests/Feature/Commands/ListProductsCommandTest.php
+++ b/tests/Feature/Commands/ListProductsCommandTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use LemonSqueezy\Laravel\LemonSqueezy;
+
+beforeEach(function () {
+    Http::fake([
+        LemonSqueezy::API.'/stores/fake' => Http::response([
+            'data' => [
+                'id' => 'fake',
+                'attributes' => [
+                    'name' => 'Fake Store',
+                    'currency' => 'EUR',
+                ],
+            ],
+        ]),
+        LemonSqueezy::API.'/products/fake?*' => Http::response([
+            'data' => [
+                'id' => 'fake',
+                'attributes' => [
+                    'name' => 'Fake Product',
+                ],
+                'relationships' => [
+                    'variants' => [
+                        'data' => [
+                            ['id' => '123'],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => '123',
+                    'type' => 'variants',
+                    'attributes' => [
+                        'name' => 'Fake Variant',
+                        'price' => 999,
+                    ],
+                ],
+            ],
+        ]),
+        LemonSqueezy::API.'/products?*' => Http::response([
+            'data' => [
+                [
+                    'id' => '1',
+                    'attributes' => [
+                        'name' => 'Pro',
+                    ],
+                    'relationships' => [
+                        'variants' => [
+                            'data' => [
+                                ['id' => '123'],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => '2',
+                    'attributes' => [
+                        'name' => 'Test',
+                    ],
+                    'relationships' => [
+                        'variants' => [
+                            'data' => [
+                                ['id' => '321'],
+                                ['id' => '456'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'included' => [
+                [
+                    'id' => '123',
+                    'type' => 'variants',
+                    'attributes' => [
+                        'name' => 'Default',
+                        'price' => 999,
+                    ],
+                ],
+                [
+                    'id' => '321',
+                    'type' => 'variants',
+                    'attributes' => [
+                        'name' => 'Monthly',
+                        'price' => 929,
+                    ],
+                ],
+                [
+                    'id' => '456',
+                    'type' => 'variants',
+                    'attributes' => [
+                        'name' => 'Yearly',
+                        'price' => 939,
+                    ],
+                ],
+            ],
+        ]),
+    ]);
+});
+
+it('can list products', function () {
+    $this->artisan('lmsqueezy:products')
+
+        // First Product
+        ->expectsOutputToContain('Pro')
+        ->expectsOutputToContain('Default €9.99')
+
+        // Second Product
+        ->expectsOutputToContain('Test')
+        ->expectsOutputToContain('Monthly €9.29')
+        ->expectsOutputToContain('Yearly €9.39')
+
+        ->assertSuccessful();
+});
+
+it('can query a specific product', function () {
+    $this->artisan('lmsqueezy:products', ['product' => 'fake'])
+        ->expectsOutputToContain('Fake Product')
+        ->expectsOutputToContain('Fake Variant €9.99')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
This Pull Request introduces the following changes:

1. New Command that can query the Lemon Squeezy API for products and variants;
2. Command can list all products and their variants or an argument can also be passed to query the variants of a specific product;

**Note:** The products query can only show 100 products since I am doing only 1 request to the endpoint using a page size of 100 (maximum), can be changed to do a recursive request to show 100, I just was thinking if It makes sense to show so many products or a message with a link to the Lemon Squeezy Dashboard.

I think at some point we should introduce a class to query products and variants as it would be nice to make that affordance available for users to query the products and variants from Lemon Squeezy, maybe even import them to a table somehow idk...

There is an decision that I made after reading the Lemon Squeezy API Docs, on the product variants I only render the pending variants if the count of variants in a products is 1.

From LemonSqueezy API Docs (https://docs.lemonsqueezy.com/api/variants):
> Note: If a variant has a pending status and its product has no other variants, it is considered the “default” variant and is not shown as a separate option at checkout.

Closes #12 

<img width="583" alt="Screenshot" src="https://github.com/lmsqueezy/laravel/assets/2780099/a43f3f17-7dce-4094-bc3c-8276e07c53e4">
