### PR TITLE
Add custom tunnel url option for lmsqueezy:listen webhooks command

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -30,7 +30,7 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
      */
     protected $signature = 'lmsqueezy:listen
                             {service : The service to use for listening to webhooks, either ngrok, expose, or custom.}
-                            {--url= : The custom URL to use for webhooks if service is custom.}
+                            {--url= : The URL to use for webhooks when using a custom service.}
                             {--cleanup : Remove all webhooks for the given service.}';
 
     /**


### PR DESCRIPTION
Instead of Ngrok or Expose I want to use a custom tunnel url for the webhook `php artisan lmsqueezy:listen` command.
I use a public url via [localcan.com](https://www.localcan.com/) for this. 

I have added a custom service that allows you to use your own tunnel url.