### PR TITLE
fix: clean up annoying empty lines and timer for expose listen in terminal

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -169,12 +169,46 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
         ];
     }
 
+    protected function cleanOutput($output)
+    {
+        if (preg_match(
+            '/Remaining time:\s+\d{2}:\d{2}:\d{2}\\n/',
+            $output,
+            $matches
+        )) {
+            $output = preg_replace('/Remaining time:\s+\d{2}:\d{2}:\d{2}\\n/', '', $output);
+        }
+
+        if ($output) {
+            $lines = explode("\n", $output);
+            $cleaned_lines = [];
+
+            foreach ($lines as $line) {
+                // Trim leading and trailing whitespace
+                $line = trim($line);
+                // Replace multiple spaces with a single space
+                $line = preg_replace('/\s+/', ' ', $line);
+
+                if (!empty($line)) {
+                    $cleaned_lines[] = $line;
+                }
+            }
+            // Join cleaned lines back into a single string
+            $output = implode("\n", $cleaned_lines);
+        }
+
+        return $output;
+    }
+
     protected function process(array $commands): InvokedProcess
     {
         return $this->process = Process::timeout(120)
             ->start($commands, function (string $type, string $output) {
                 if ($this->option('verbose') || isset($this->webhookId)) {
-                    note($output);
+                    $output = $this->cleanOutput($output);
+                    if ($output) {
+                        note($output);
+                    }
                 }
             });
     }


### PR DESCRIPTION
Removed annoying "Remaining time:"  empty lines from terminal when running expose.

Before: 
![Screenshot 2024-07-23 at 16 21 55](https://github.com/user-attachments/assets/cc6dac44-2caf-492d-bf80-0c3df921caa1)


After:
![Screenshot 2024-07-23 at 16 21 24](https://github.com/user-attachments/assets/2ee01b1a-7659-48f4-a1b9-a1c2cdd9bf45)
