### PR TITLE
Creates the license key feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The below features are not yet in this package but are planned to be added in th
 
 - Subscription invoices
 - [Usage Based Billing](https://github.com/lmsqueezy/laravel/issues/55)
-- License keys
 - Marketing emails check
 - Create discount codes
 - [Nova integration](https://github.com/lmsqueezy/laravel/issues/51)
@@ -941,6 +940,27 @@ $user->subscription()->endTrial();
 ```
 
 This method will move the billing achor to the current day and thus ending any trial period the customer had.
+
+## License Keys
+
+License keys can be activated and validated using the license key string. A license key instance will be stored in 
+the database for each activated license. 
+
+**Please note:** the billable for the license is the billable that purchased the license key, but _not necessarily the 
+user who activated the license key_, so you should establish a relationship between a license key instance and the user
+creating it yourself.
+
+To activate a license key and retrieve a license key instance:
+
+```php
+$user->activateLicenseKey('your-key', 'your-reference')
+```
+
+To validate a license key:
+```php
+$user->activateLicenseKey('your-key', 'your-reference')
+```
+
 
 ## Handling Webhooks
 

--- a/database/factories/LicenseKeyFactory.php
+++ b/database/factories/LicenseKeyFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use LemonSqueezy\Laravel\LicenseKey;
+
+class LicenseKeyFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = LicenseKey::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'lemon_squeezy_id' => rand(1, 1000),
+            'status' => LicenseKey::STATUS_ACTIVE,
+            'disabled' => false,
+            'license_key' => $this->faker->uuid(),
+            'product_id' => rand(1, 1000),
+            'order_id' => rand(1, 1000),
+            'activation_limit' => 0,
+            'instances_count' =>  0,
+            'expires_at' => null,
+            'updated_at' => null
+        ];
+    }
+
+    /**
+     * Mark the license key as active.
+     */
+    public function active(): self
+    {
+        return $this->state([
+            'status' => LicenseKey::STATUS_ACTIVE,
+        ]);
+    }
+
+    /**
+     * Disable the license key.
+     */
+    public function disable(): self
+    {
+        return $this->state([
+            'disabled' => true,
+            'status' => LicenseKey::STATUS_DISABLED,
+        ]);
+    }
+}

--- a/database/migrations/2023_01_16_000004_create_license_keys_table.php
+++ b/database/migrations/2023_01_16_000004_create_license_keys_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lemon_squeezy_license_keys', function (Blueprint $table) {
+            $table->id();
+            $table->string('lemon_squeezy_id')->unique();
+            $table->string('license_key')->unique();
+            $table->string('status');
+            $table->string('order_id')->index();
+            $table->string('product_id')->index();
+            $table->boolean('disabled');
+            $table->integer('activation_limit')->nullable();
+            $table->integer('instances_count');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('order_id')->references('lemon_squeezy_id')->on('lemon_squeezy_orders');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lemon_squeezy_license_keys');
+    }
+};

--- a/database/migrations/2023_01_16_000005_create_license_key_instances_table.php
+++ b/database/migrations/2023_01_16_000005_create_license_key_instances_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lemon_squeezy_license_key_instances', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('identifier')->unique();
+            $table->string('license_key_id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lemon_squeezy_license_key_instances');
+    }
+};

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -4,6 +4,7 @@ namespace LemonSqueezy\Laravel;
 
 use LemonSqueezy\Laravel\Concerns\ManagesCheckouts;
 use LemonSqueezy\Laravel\Concerns\ManagesCustomer;
+use LemonSqueezy\Laravel\Concerns\ManagesLicenses;
 use LemonSqueezy\Laravel\Concerns\ManagesOrders;
 use LemonSqueezy\Laravel\Concerns\ManagesSubscriptions;
 
@@ -11,6 +12,7 @@ trait Billable
 {
     use ManagesCheckouts;
     use ManagesCustomer;
+    use ManagesLicenses;
     use ManagesOrders;
     use ManagesSubscriptions;
 }

--- a/src/Concerns/ManagesLicenses.php
+++ b/src/Concerns/ManagesLicenses.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Concerns;
+
+use LemonSqueezy\Laravel\Exceptions\LemonSqueezyApiError;
+use LemonSqueezy\Laravel\Exceptions\LicenseKeyNotFound;
+use LemonSqueezy\Laravel\Exceptions\LicenseKeyNotValidated;
+use LemonSqueezy\Laravel\Exceptions\MalformedDataError;
+use LemonSqueezy\Laravel\LemonSqueezy;
+use LemonSqueezy\Laravel\LicenseKey;
+use LemonSqueezy\Laravel\LicenseKeyInstance;
+
+trait ManagesLicenses
+{
+    /**
+     * Activate a license key.
+     *
+     * @param string $key The license key
+     * @param string $reference External reference to store in Lemonsqueezy
+     *
+     * @throws MalformedDataError
+     * @throws LemonSqueezyApiError
+     * @throws LicenseKeyNotFound
+     */
+    public function activateLicense(string $key, string $reference): LicenseKeyInstance
+    {
+        if (!LicenseKey::notDisabled()->withKey($key)->exists()) {
+            throw LicenseKeyNotFound::withKey($key);
+        }
+
+        $res = LemonSqueezy::api('POST', 'licenses/activate', [
+            'license_key' => $key,
+            'instance_name' => $reference,
+        ]);
+
+        return LicenseKeyInstance::fromPayload($res->json());
+    }
+
+    /**
+     * @throws MalformedDataError
+     * @throws LicenseKeyNotValidated
+     */
+    public function assertValid(string $licenseKey, ?string $instanceId = null): LicenseKey {
+        try {
+            $res = LemonSqueezy::api('POST', 'licenses/validate', [
+                'license_key' => $licenseKey,
+                'instance_id' => $instanceId,
+            ]);
+        } catch (LemonSqueezyApiError $e) {
+            throw LicenseKeyNotValidated::withErrorMessage($e->getMessage());
+        }
+
+        return LicenseKey::fromPayload($res['data']);
+    }
+}

--- a/src/Events/LicenseKeyCreated.php
+++ b/src/Events/LicenseKeyCreated.php
@@ -5,25 +5,14 @@ namespace LemonSqueezy\Laravel\Events;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use LemonSqueezy\Laravel\LicenseKey;
 
 class LicenseKeyCreated
 {
     use Dispatchable;
     use SerializesModels;
 
-    /**
-     * The billable entity.
-     */
-    public Model $billable;
-
-    /**
-     * The payload array.
-     */
-    public array $payload;
-
-    public function __construct(Model $billable, array $payload)
+    public function __construct(public readonly Model $billable, public readonly LicenseKey $licenseKey)
     {
-        $this->billable = $billable;
-        $this->payload = $payload;
     }
 }

--- a/src/Events/LicenseKeyUpdated.php
+++ b/src/Events/LicenseKeyUpdated.php
@@ -5,25 +5,14 @@ namespace LemonSqueezy\Laravel\Events;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use LemonSqueezy\Laravel\LicenseKey;
 
 class LicenseKeyUpdated
 {
     use Dispatchable;
     use SerializesModels;
 
-    /**
-     * The billable entity.
-     */
-    public Model $billable;
-
-    /**
-     * The payload array.
-     */
-    public array $payload;
-
-    public function __construct(Model $billable, array $payload)
+    public function __construct(public readonly Model $billable, public readonly LicenseKey $licenseKey)
     {
-        $this->billable = $billable;
-        $this->payload = $payload;
     }
 }

--- a/src/Exceptions/InvalidCustomPayload.php
+++ b/src/Exceptions/InvalidCustomPayload.php
@@ -3,8 +3,13 @@
 namespace LemonSqueezy\Laravel\Exceptions;
 
 use Exception;
+use LemonSqueezy\Laravel\Http\Throwable\BadRequest;
 
-class InvalidCustomPayload extends Exception
+class InvalidCustomPayload extends Exception implements BadRequest
 {
-    //
+
+    public function __construct(string $message = '')
+    {
+        parent::__construct($message ?? 'Invalid custom data');
+    }
 }

--- a/src/Exceptions/LicenseKeyNotFound.php
+++ b/src/Exceptions/LicenseKeyNotFound.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Exceptions;
+
+use LemonSqueezy\Laravel\Http\Throwable\NotFound;
+
+class LicenseKeyNotFound extends \Exception implements NotFound
+{
+    public static function withKey(string $key): static {
+        return new self("No license found for key {$key}");
+    }
+}

--- a/src/Exceptions/LicenseKeyNotValidated.php
+++ b/src/Exceptions/LicenseKeyNotValidated.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Exceptions;
+
+use LemonSqueezy\Laravel\Http\Throwable\BadRequest;
+class LicenseKeyNotValidated extends \Exception implements BadRequest
+{
+    public static function withErrorMessage(string $message): static {
+        return new self("The license key couldn't be validated: {$message}");
+    }
+}

--- a/src/Exceptions/MalformedDataError.php
+++ b/src/Exceptions/MalformedDataError.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Exceptions;
+
+use Illuminate\Validation\Validator;
+use LemonSqueezy\Laravel\Http\Throwable\BadRequest;
+
+class MalformedDataError extends \Exception implements BadRequest
+{
+    public static function forLicenseKey(Validator $validator): static
+    {
+        return new static('LicenseKey key data is malformed:' . $validator->errors());
+    }
+}

--- a/src/Exceptions/ReservedCustomKeys.php
+++ b/src/Exceptions/ReservedCustomKeys.php
@@ -3,8 +3,9 @@
 namespace LemonSqueezy\Laravel\Exceptions;
 
 use Exception;
+use LemonSqueezy\Laravel\Http\Throwable\BadRequest;
 
-class ReservedCustomKeys extends Exception
+class ReservedCustomKeys extends Exception implements BadRequest
 {
     public static function overwriteAttempt(): ReservedCustomKeys
     {

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -25,6 +25,8 @@ use LemonSqueezy\Laravel\Events\WebhookHandled;
 use LemonSqueezy\Laravel\Events\WebhookReceived;
 use LemonSqueezy\Laravel\Exceptions\InvalidCustomPayload;
 use LemonSqueezy\Laravel\Http\Middleware\VerifyWebhookSignature;
+use LemonSqueezy\Laravel\Http\Throwable\BadRequest;
+use LemonSqueezy\Laravel\Http\Throwable\NotFound;
 use LemonSqueezy\Laravel\LemonSqueezy;
 use LemonSqueezy\Laravel\Order;
 use LemonSqueezy\Laravel\Subscription;
@@ -60,8 +62,12 @@ final class WebhookController extends Controller
         if (method_exists($this, $method)) {
             try {
                 $this->{$method}($payload);
-            } catch (InvalidCustomPayload $e) {
-                return new Response('Webhook skipped due to invalid custom data.');
+            } catch (BadRequest $e) {
+                return new Response($e->getMessage(), 400);
+            } catch (NotFound $e) {
+                return new Response($e->getMessage(), 404);
+            } catch (\Exception $e) {
+                return new Response(sprintf('Internal server error: %s', $e->getMessage()), 500);
             }
 
             WebhookHandled::dispatch($payload);

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -24,10 +24,13 @@ use LemonSqueezy\Laravel\Events\SubscriptionUpdated;
 use LemonSqueezy\Laravel\Events\WebhookHandled;
 use LemonSqueezy\Laravel\Events\WebhookReceived;
 use LemonSqueezy\Laravel\Exceptions\InvalidCustomPayload;
+use LemonSqueezy\Laravel\Exceptions\LicenseKeyNotFound;
+use LemonSqueezy\Laravel\Exceptions\MalformedDataError;
 use LemonSqueezy\Laravel\Http\Middleware\VerifyWebhookSignature;
 use LemonSqueezy\Laravel\Http\Throwable\BadRequest;
 use LemonSqueezy\Laravel\Http\Throwable\NotFound;
 use LemonSqueezy\Laravel\LemonSqueezy;
+use LemonSqueezy\Laravel\LicenseKey;
 use LemonSqueezy\Laravel\Order;
 use LemonSqueezy\Laravel\Subscription;
 use Symfony\Component\HttpFoundation\Response;
@@ -265,18 +268,31 @@ final class WebhookController extends Controller
         }
     }
 
+    /**
+     * @throws MalformedDataError
+     */
     private function handleLicenseKeyCreated(array $payload): void
     {
-        $billable = $this->resolveBillable($payload);
+        $licenseKey = LicenseKey::fromPayload($payload);
 
-        LicenseKeyCreated::dispatch($billable, $payload);
+        LicenseKeyCreated::dispatch($licenseKey->billable(), $licenseKey);
     }
 
+    /**
+     * @throws LicenseKeyNotFound
+     */
     private function handleLicenseKeyUpdated(array $payload): void
     {
-        $billable = $this->resolveBillable($payload);
+        $key = $payload['data']['attributes']['key'] ?? '';
+        $licenseKey = LicenseKey::withKey($key)->first();
 
-        LicenseKeyUpdated::dispatch($billable, $payload);
+        if ($licenseKey === null) {
+            throw LicenseKeyNotFound::withKey($key);
+        }
+
+        $licenseKey = $licenseKey->sync($payload['data']['attributes']);
+
+        LicenseKeyUpdated::dispatch($licenseKey->billable(), $licenseKey);
     }
 
     /**

--- a/src/Http/Throwable/BadRequest.php
+++ b/src/Http/Throwable/BadRequest.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Http\Throwable;
+
+interface BadRequest extends \Throwable {}

--- a/src/Http/Throwable/NotFound.php
+++ b/src/Http/Throwable/NotFound.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace LemonSqueezy\Laravel\Http\Throwable;
+
+interface NotFound extends \Throwable {}

--- a/src/LicenseKey.php
+++ b/src/LicenseKey.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace LemonSqueezy\Laravel;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\Validator;
+use LemonSqueezy\Laravel\Database\Factories\LicenseKeyFactory;
+use LemonSqueezy\Laravel\Exceptions\MalformedDataError;
+
+/**
+ * The LicenseKey Key object
+ * https://docs.lemonsqueezy.com/api/license-keys/the-license-key-object
+ */
+class LicenseKey extends Model
+{
+    use HasFactory;
+
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_INACTIVE = 'inactive';
+    public const STATUS_EXPIRED = 'expired';
+    public const STATUS_DISABLED = 'disabled';
+    private const KEY_ID = 'id';
+    private const KEY_DISABLED = 'disabled';
+    private const KEY_KEY = 'key';
+    private const KEY_KEY_SHORT = 'key_short';
+    private const KEY_ACTIVATION_LIMIT = 'activation_limit';
+    private const KEY_INSTANCES_COUNT = 'instances_count';
+    private const KEY_PRODUCT_ID = 'product_id';
+    private const KEY_ORDER_ID = 'order_id';
+    private const KEY_STATUS = 'status';
+    private const KEY_EXPIRES_AT = 'expires_at';
+    private const KEY_CREATED_AT = 'created_at';
+    private const KEY_UPDATED_AT = 'updated_at';
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'lemon_squeezy_license_keys';
+
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'activation_limit' => 'integer',
+        'instances_count' => 'integer',
+        'expired_at' => 'datetime',
+    ];
+
+    /**
+     * @throws MalformedDataError
+     */
+    public static function fromPayload(array $payload): LicenseKey {
+        $validator = Validator::make(array_merge([self::KEY_ID => $payload[self::KEY_ID]], $payload['attributes']), [
+            self::KEY_ID                => ['required', 'string'],
+            self::KEY_KEY               => ['required', 'string'],
+            self::KEY_KEY_SHORT         => ['required', 'string'],
+            self::KEY_ACTIVATION_LIMIT  => ['required', 'numeric'],
+            self::KEY_PRODUCT_ID        => ['required'],
+            self::KEY_ORDER_ID          => ['required'],
+            self::KEY_STATUS            => ['required'],
+            self::KEY_CREATED_AT        => ['required', 'date'],
+        ]);
+
+        if (!$validator->passes()) {
+            throw MalformedDataError::forLicenseKey($validator);
+        }
+
+        $attributes = $payload['attributes'];
+
+        $licenseKey = LicenseKey::create([
+            'lemon_squeezy_id' => $payload[self::KEY_ID],
+            'status' => $attributes[self::KEY_STATUS],
+            'disabled' => $attributes[self::KEY_DISABLED] ?? false,
+            'license_key' => $attributes[self::KEY_KEY],
+            'product_id' => $attributes[self::KEY_PRODUCT_ID],
+            'order_id' => $attributes[self::KEY_ORDER_ID],
+            'activation_limit' => $attributes[self::KEY_ACTIVATION_LIMIT],
+            'instances_count' => $attributes[self::KEY_INSTANCES_COUNT] ?? 0,
+            'expires_at' => isset($attributes[self::KEY_EXPIRES_AT])
+                ? Carbon::make($attributes[self::KEY_EXPIRES_AT])
+                : null,
+            'created_at' => $attributes[self::KEY_CREATED_AT],
+            'updated_at' => isset($attributes[self::KEY_UPDATED_AT])
+                ? Carbon::make($attributes[self::KEY_UPDATED_AT]) : null,
+        ]);
+
+        return $licenseKey;
+    }
+
+    /**
+     * The order this license key was generated for
+     */
+    public function order(): BelongsTo {
+        return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * The billable that purchased the license
+     */
+    public function billable(): Model {
+        return $this->order()->first()->billable;
+    }
+
+    /**
+     * Check if the license key is active.
+     */
+    public function isActive(): bool
+    {
+        return $this->status === self::STATUS_ACTIVE;
+    }
+
+    /**
+     * Filter query by active.
+     */
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('status', self::STATUS_ACTIVE);
+    }
+
+    /**
+     * Filter query by enabled.
+     */
+    public function scopeNotDisabled(Builder $query): void
+    {
+        $query->where('disabled', false);
+    }
+
+    /**
+     * Filter query by license key.
+     */
+    public function scopeWithKey(Builder $query, string $key): void
+    {
+        $query->where('license_key', $key);
+    }
+
+    /**
+     * Check if the license key is inactive.
+     */
+    public function inactive(): bool
+    {
+        return $this->status === self::STATUS_INACTIVE;
+    }
+
+    /**
+     * Filter query by inactive.
+     */
+    public function scopeInactive(Builder $query): void
+    {
+        $query->where('status', self::STATUS_INACTIVE);
+    }
+
+    /**
+     * Check if the license key is disabled.
+     */
+    public function disabled(): bool
+    {
+        return $this->status === self::STATUS_DISABLED;
+    }
+
+    /**
+     * Filter query by disabled.
+     */
+    public function scopeDisabled(Builder $query): void
+    {
+        $query->where('status', self::STATUS_DISABLED);
+    }
+
+    /**
+     * Check if the license key is expired.
+     */
+    public function expired(): bool
+    {
+        return $this->status === self::STATUS_EXPIRED;
+    }
+
+    /**
+     * Filter query by expired.
+     */
+    public function scopeExpired(Builder $query): void
+    {
+        $query->where('status', self::STATUS_EXPIRED);
+    }
+
+    /**
+     * Determine if the license is for a specific product.
+     */
+    public function hasProduct(string $productId): bool
+    {
+        return $this->product_id === $productId;
+    }
+
+    /**
+     * Sync the license key with the given payload data.
+     */
+    public function sync(array $attributes): self
+    {
+        $this->update([
+            'status' => $attributes[self::KEY_STATUS],
+            'disabled' => $attributes[self::KEY_DISABLED],
+            'product_id' => $attributes[self::KEY_PRODUCT_ID],
+            'activation_limit' => $attributes[self::KEY_ACTIVATION_LIMIT],
+            'instances_count' => $attributes[self::KEY_INSTANCES_COUNT],
+            'expires_at' => isset($attributes[self::KEY_EXPIRES_AT])
+                ? Carbon::make($attributes[self::KEY_EXPIRES_AT])
+                : null,
+            'updated_at' => Carbon::make($attributes[self::KEY_EXPIRES_AT]),
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): LicenseKeyFactory
+    {
+        return LicenseKeyFactory::new();
+    }
+}

--- a/src/LicenseKeyInstance.php
+++ b/src/LicenseKeyInstance.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LemonSqueezy\Laravel;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Validator;
+use LemonSqueezy\Laravel\Exceptions\MalformedDataError;
+
+class LicenseKeyInstance extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'lemon_squeezy_license_key_instances';
+
+    protected $guarded = [];
+
+    /**
+     * @throws MalformedDataError
+     */
+    public static function fromPayload(array $payload): static {
+        $validator = Validator::make($payload, [
+            'license_key.id'   => ['required'],
+            'instance.id'      => ['required', 'string'],
+            'instance.name'    => ['required', 'string'],
+        ]);
+
+        if (!$validator->passes()) {
+            throw MalformedDataError::forLicenseKey($validator);
+        }
+
+        $licenseKey = LicenseKey::notDisabled()->withKey($payload['license_key']['key'])->first();
+
+        return LicenseKeyInstance::create([
+            'identifier' => $payload['instance']['id'],
+            'license_key_id' => $licenseKey->id,
+            'name' => $payload['instance']['name'],
+        ]);
+    }
+
+    public function licenseKey(): BelongsTo {
+        return $this->belongsTo(LicenseKey::class);
+    }
+
+    public function active(Builder $query): void {
+        $query
+            ->join('license_keys', 'license_keys.id', '=', 'license_key_instances.license_key_id')
+            ->where('license_keys.status', LicenseKey::STATUS_ACTIVE);
+    }
+}

--- a/tests/Feature/LicenseTest.php
+++ b/tests/Feature/LicenseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use LemonSqueezy\Laravel\LicenseKey;
+use LemonSqueezy\Laravel\Exceptions\LicenseKeyNotFound;
+use LemonSqueezy\Laravel\LicenseKeyInstance;
+use Tests\Fixtures\User;
+
+it('can activate a license', function () {
+    $key = LicenseKey::factory()->create();
+    $reference = 'some-reference';
+
+    Http::fake([
+        'api.lemonsqueezy.com/v1/licenses/activate' => Http::response([
+            'license_key' => [
+                'id' => 'foo',
+                'key' => $key->license_key,
+            ],
+            'instance' => [
+                'id' => 'foo',
+                'name' => $reference,
+            ]
+        ]),
+    ]);
+
+    (new User)->activateLicense($key->license_key, $reference);
+
+    expect(LicenseKeyInstance::where('identifier', '=', 'foo')->exists())->toBeTrue();
+});
+
+it('fails if license not found', function () {
+    (new User)->activateLicense('some-key', 'some-reference');
+})->throws(LicenseKeyNotFound::class);
+


### PR DESCRIPTION
Sorry this took me a while! This PR introduces the license keys feature, including two new migrations for license keys and license key instances.

It introduces a new trait with billable methods for activating and validating a license key, and handles the events related to license keys.

I ran into some snags re: the ngrok listen command so a PR for that may or may not follow depending on how swamped I get :sweat_smile: LMK if there's any questions