### PR TITLE
chore: bumping package version to 1.8.4 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "lemon squeezy",
         "billing"
     ],
-    "version": "1.8.2",
+    "version": "1.8.4",
     "license": "MIT",
     "support": {
         "issues": "https://github.com/lmsqueezy/laravel/issues",


### PR DESCRIPTION
This PR should fix issue: #132.  I think we forgot to be bumping the versions. packagist completely ignored the 1.8.3 and 1.8.4 releases. The composer docs recommends we should omit it completely and let composer infer the version from the release tags. which is better? https://getcomposer.org/doc/04-schema.md#version