### PR TITLE
fix: fixing #139

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -289,7 +289,9 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
                             $request['response']['status_code'],
                             $request['request']['method'],
                             Str::padRight(Str::limit($request['request']['uri'], 48, ''), 48, '.'),
-                            Carbon::parse($request['response']['headers']['Date'][0])->format('H:i:s'),
+                            isset($request['response']['headers']['Date'][0])
+                                ? Carbon::parse($request['response']['headers']['Date'][0])->format('H:i:s')
+                                : '[Date-Not-Set]',
                         ));
                     }
                 }


### PR DESCRIPTION
This pull request includes a small change to the `src/Console/ListenCommand.php` file. The change improves the handling of the `Date` header in the `ngrok` function by adding a check to see if the `Date` header is set before attempting to parse it.

* [`src/Console/ListenCommand.php`](diffhunk://#diff-070ddc3a61bc9c230ffacaef353905639b9f624664c4210fbf2cbc7aeaca4c6cL292-R294): Added a check to ensure the `Date` header is set before parsing it, and provided a default value of `[Date-Not-Set]` if it is not present.