### PR TITLE
fix license key updated webhook handler

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -294,7 +294,9 @@ final class WebhookController extends Controller
 
         $licenseKey = $licenseKey->sync($payload['data']['attributes']);
 
-        LicenseKeyUpdated::dispatch($licenseKey->billable(), $licenseKey);
+        $billable = $this->resolveBillable($payload);
+
+        LicenseKeyUpdated::dispatch($billable, $licenseKey);
     }
 
     /**


### PR DESCRIPTION
Instead of getting billable from $licenseKey, we may resolve that from the payload
