### PR TITLE
Fix #145: use a new regex for expose listen command

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -226,12 +226,31 @@ class ListenCommand extends Command implements Isolatable, PromptsForMissingInpu
             '--no-interaction',
         ]);
 
+
+        $oldRegex = '/Public HTTPS:\s+(http[s]?:\/\/[^\s]+)/';
+        $newRegex = '/Public URL\s+([^\s]+)/';
+
         while ($this->process->running()) {
-            if (is_null($tunnel) && preg_match(
-                '/Public HTTPS:\s+(http[s]?:\/\/[^\s]+)/',
-                $this->process->latestOutput(),
-                $matches,
-            )) {
+
+            if ($tunnel !== null) {
+                sleep(1);
+
+                continue;
+            }
+
+            $latestOutput = $this->process->latestOutput();
+
+            if (preg_match($oldRegex, $latestOutput, $matches)) {
+                $tunnel = $matches[1];
+
+                $errorCode = $this->setupWebhook($tunnel);
+
+                if ($errorCode !== null) {
+                    return $errorCode;
+                }
+            }
+
+            if (preg_match($newRegex, $latestOutput, $matches)) {
                 $tunnel = $matches[1];
 
                 $errorCode = $this->setupWebhook($tunnel);


### PR DESCRIPTION
As described in #145 the regex is no longer valid. But since maybe an old version of expose could still use the old one, I kept it and added a new regex for the new format. This sounds safer to me.