### PR TITLE
Fix billable_type casting in ManagesCheckouts to avoid error for numeric morph key

### DIFF
--- a/src/Concerns/ManagesCheckouts.php
+++ b/src/Concerns/ManagesCheckouts.php
@@ -18,7 +18,7 @@ trait ManagesCheckouts
         // checkout so we can match it back to a user when handling Lemon Squeezy webhooks.
         $custom = array_merge($custom, [
             'billable_id' => (string) $this->getKey(),
-            'billable_type' => $this->getMorphClass(),
+            'billable_type' => (string) $this->getMorphClass(),
         ]);
 
         return Checkout::make($this->lemonSqueezyStore(), $variant)


### PR DESCRIPTION
Many devs are using an integer as a morph key.
We need to cast it as a string as the LemonSqueezy API expect only string values.

Otherwise, you will get below error
```
The checkout_data.custom.billable_type field must be a string. {"userId":1,"exception":"[object] (LemonSqueezy\\Laravel\\Exceptions\\LemonSqueezyApiError(code: 422): The checkout_data.custom.billable_type field must be a string.
```